### PR TITLE
Fix: create config file only if necessary

### DIFF
--- a/isortd/main.py
+++ b/isortd/main.py
@@ -10,6 +10,7 @@ from typing import Mapping
 import aiohttp_cors
 import click
 from aiohttp import web
+from isort import __version__ as isort_ver
 from isort import code, settings
 from isort.exceptions import ISortError
 
@@ -23,7 +24,9 @@ def main(host, port):
     logging.basicConfig(level=logging.INFO)
     with futures.ProcessPoolExecutor() as executor:
         app = factory(executor)
-        app.logger.info(f"isortd version {ver} listening on {host} port {port}")
+        app.logger.info(
+            f"isortd v{ver} (isort core v{isort_ver}) listening on {host} port {port}"
+        )
         web.run_app(app, host=host, port=port, handle_signals=True) or 0
     return 0
 

--- a/isortd/main.py
+++ b/isortd/main.py
@@ -92,7 +92,7 @@ class Handler:
     def _parse_arguments(self, headers: Mapping) -> tuple[str, ...]:
         normalized = tuple(
             sorted(
-                f"{self._map_to_arv(key)}={value}"
+                f"{self._map_to_arg(key)}={value}"
                 for key, value in headers.items()
                 if key.startswith("X-")
             )
@@ -100,9 +100,8 @@ class Handler:
         return normalized
 
     @staticmethod
-    def _map_to_arv(key: str):
-        double_dash_key = key.lower().replace("x-", "")
-        return double_dash_key
+    def _map_to_arg(key: str):
+        return key.lower().replace("x-", "")
 
     @lru_cache()
     def _get_config(self, args: tuple[str, ...], src: list[str]):

--- a/isortd/main.py
+++ b/isortd/main.py
@@ -71,18 +71,13 @@ class Handler:
     async def handle(self, request: web.Request):
         in_ = await request.text()
         try:
-            fp = request.headers.get("XX-PATH")
-            src = tuple(request.headers.get("XX-SRC", "").split(","))
+            fp = request.headers.get('XX-PATH')
+            src = tuple(request.headers.get('XX-SRC', '').split(','))
             args = self._parse_arguments(request.headers)
             cfg = self._get_config(args, src)
         except ISortError as e:
             return web.Response(body=f"Failed to parse config: {e}", status=400)
-        out = code(
-            code=in_,
-            config=cfg,
-            file_path=Path(fp) if fp else None,
-            disregard_skip=True,
-        )
+        out = code(code=in_, config=cfg, file_path=Path(fp) if fp else None, disregard_skip=True)
         if out:
             return web.Response(
                 text=out, content_type=request.content_type, charset=request.charset
@@ -90,13 +85,9 @@ class Handler:
         return web.Response(status=201)
 
     def _parse_arguments(self, headers: Mapping) -> tuple[str, ...]:
-        normalized = tuple(
-            sorted(
-                f"{self._map_to_arg(key)}={value}"
-                for key, value in headers.items()
-                if key.startswith("X-")
-            )
-        )
+        normalized = tuple(sorted(f'{self._map_to_arg(key)}={value}'
+                                  for key, value in headers.items()
+                                  if key.startswith("X-")))
         return normalized
 
     @staticmethod
@@ -107,10 +98,10 @@ class Handler:
     def _get_config(self, args: tuple[str, ...], src: list[str]):
         kwargs = {}
         if args:
-            with tempfile.NamedTemporaryFile("w", suffix=".toml", delete=False) as tmp:
-                tmp.write("\n".join(("[tool.isort]", *args)))
+            with tempfile.NamedTemporaryFile('w', suffix='.toml', delete=False) as tmp:
+                tmp.write('\n'.join(('[tool.isort]', *args)))
                 file_path = tmp.name
-            kwargs["settings_file"] = file_path
+            kwargs['settings_file'] = file_path
         if src:
-            kwargs["src_paths"] = src
+            kwargs['src_paths'] = src
         return settings.Config(**kwargs)

--- a/isortd/main.py
+++ b/isortd/main.py
@@ -23,7 +23,7 @@ def main(host, port):
     logging.basicConfig(level=logging.INFO)
     with futures.ProcessPoolExecutor() as executor:
         app = factory(executor)
-        app.logger.info(f"isortd version {ver} istening on {host} port {port}")
+        app.logger.info(f"isortd version {ver} listening on {host} port {port}")
         web.run_app(app, host=host, port=port, handle_signals=True) or 0
     return 0
 

--- a/isortd/main.py
+++ b/isortd/main.py
@@ -68,13 +68,18 @@ class Handler:
     async def handle(self, request: web.Request):
         in_ = await request.text()
         try:
-            fp = request.headers.get('XX-PATH')
-            src = tuple(request.headers.get('XX-SRC', '').split(','))
+            fp = request.headers.get("XX-PATH")
+            src = tuple(request.headers.get("XX-SRC", "").split(","))
             args = self._parse_arguments(request.headers)
             cfg = self._get_config(args, src)
         except ISortError as e:
             return web.Response(body=f"Failed to parse config: {e}", status=400)
-        out = code(code=in_, config=cfg, file_path=Path(fp) if fp else None, disregard_skip=True)
+        out = code(
+            code=in_,
+            config=cfg,
+            file_path=Path(fp) if fp else None,
+            disregard_skip=True,
+        )
         if out:
             return web.Response(
                 text=out, content_type=request.content_type, charset=request.charset
@@ -82,9 +87,13 @@ class Handler:
         return web.Response(status=201)
 
     def _parse_arguments(self, headers: Mapping) -> tuple[str, ...]:
-        normalized = tuple(sorted(f'{self._map_to_arv(key)}={value}'
-                                  for key, value in headers.items()
-                                  if key.startswith("X-")))
+        normalized = tuple(
+            sorted(
+                f"{self._map_to_arv(key)}={value}"
+                for key, value in headers.items()
+                if key.startswith("X-")
+            )
+        )
         return normalized
 
     @staticmethod
@@ -94,10 +103,10 @@ class Handler:
 
     @lru_cache()
     def _get_config(self, args: tuple[str, ...], src: list[str]):
-        with tempfile.NamedTemporaryFile('w', suffix='.toml', delete=False) as tmp:
-            tmp.write('\n'.join(('[tool.isort]', *args)))
+        with tempfile.NamedTemporaryFile("w", suffix=".toml", delete=False) as tmp:
+            tmp.write("\n".join(("[tool.isort]", *args)))
             file_path = tmp.name
         kwargs = {}
         if src:
-            kwargs['src_paths'] = src
+            kwargs["src_paths"] = src
         return settings.Config(settings_file=file_path, **kwargs)

--- a/isortd/main.py
+++ b/isortd/main.py
@@ -103,10 +103,12 @@ class Handler:
 
     @lru_cache()
     def _get_config(self, args: tuple[str, ...], src: list[str]):
-        with tempfile.NamedTemporaryFile("w", suffix=".toml", delete=False) as tmp:
-            tmp.write("\n".join(("[tool.isort]", *args)))
-            file_path = tmp.name
         kwargs = {}
+        if args:
+            with tempfile.NamedTemporaryFile("w", suffix=".toml", delete=False) as tmp:
+                tmp.write("\n".join(("[tool.isort]", *args)))
+                file_path = tmp.name
+            kwargs["settings_file"] = file_path
         if src:
             kwargs["src_paths"] = src
-        return settings.Config(settings_file=file_path, **kwargs)
+        return settings.Config(**kwargs)


### PR DESCRIPTION
Fixes warning which occurs because isortd creates an empty config file if no args are given.

```
.venv/lib/python3.9/site-packages/isort/settings.py:287: 
UserWarning: A custom settings file was specified: 
/var/folders/_g/nfj48t2948s35nnrcs4p3q_c0000gn/T/tmp1py5a0sg.toml 
but no configuration was found inside. 
This can happen when [settings] is used as the config header instead of [isort]. See: 
https://pycqa.github.io/isort/docs/configuration/config_files/#custom_config_files for more information.
```

This changes it to only create the isort config file if args are given.

(I also formatted the code using Black. Let me know if this is not desired.)