### PR TITLE
fix: fix usage of lru_cache to support older python

### DIFF
--- a/isortd/main.py
+++ b/isortd/main.py
@@ -107,7 +107,7 @@ def _normalize_headers(key: str):
     return key.lower().replace("x-", "")
 
 
-@lru_cache
+@lru_cache(maxsize=128)
 def _get_config(args: tuple[str, ...], src: list[str]):
     kwargs = {}
     if args:


### PR DESCRIPTION
The *user_function* signature of `functools.lru_cache` is introduced in Python 3.8, we should set `maxsize` explicitly to support older versions of Python.

```
Traceback (most recent call last):
  File "/_/_/.pyenv/versions/3.7.10/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/_/_/.pyenv/versions/3.7.10/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/_/_/Workspace/git/isortd/isortd/__main__.py", line 3, in <module>
    from isortd.main import main
  File "/_/_/Workspace/git/isortd/isortd/main.py", line 111, in <module>
    @lru_cache
  File "/_/_/.pyenv/versions/3.7.10/lib/python3.7/functools.py", line 490, in lru_cache
    raise TypeError('Expected maxsize to be an integer or None')
TypeError: Expected maxsize to be an integer or None
```